### PR TITLE
test-kitchenに対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source :rubygems
 
+gem "test-kitchen"
 gem "vagrant",   "~> 1.0.7"
 gem "berkshelf", "~> 1.2.1"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@ when 'redhat', 'centos'
     yum::repoforge
   })
 when 'ubuntu', 'debian'
-  default['xbuild']['depends'] = %{
+  default['xbuild']['depends'] = %w{
     build-essential
     openssl
     libssl-dev
@@ -30,6 +30,7 @@ when 'ubuntu', 'debian'
     libxml2-dev
     libcurl4-gnutls-dev
     libjpeg62-dev
+    libxslt1-dev
     re2c
   }
 end

--- a/recipes/test.rb
+++ b/recipes/test.rb
@@ -1,3 +1,5 @@
+include_recipe 'xbuild::default'
+
 xbuild_perl "install test perl #{node['perl']['version']}" do
   version node['perl']['version']
   prefix  node['perl']['prefix']
@@ -12,7 +14,7 @@ xbuild_php "install test php #{node['php']['version']}" do
   version node['php']['version']
   options node['php']['options']
   prefix  node['php']['prefix']
-end
+end if node[:platform_family] == 'rhel'
 
 xbuild_python "install test python #{node['python']['version']}" do
   version node['python']['version']

--- a/test/kitchen/Kitchenfile
+++ b/test/kitchen/Kitchenfile
@@ -1,0 +1,25 @@
+platform :centos do
+  version '6.3' do
+    box "opscode-centos-6.3"
+    box_url "https://opscode-vm.s3.amazonaws.com/vagrant/boxes/opscode-centos-6.3.box"
+  end
+end
+
+platform :ubuntu do
+  version '12.04' do
+    box "opscode-ubuntu-12.04"
+    box_url "https://opscode-vm.s3.amazonaws.com/vagrant/boxes/opscode-ubuntu-12.04.box"
+  end
+end
+
+cookbook "xbuild" do
+  ## skip foodcritic
+  memory 1024
+  lint false
+
+  run_list_extras ['xbuild_attributes::default']
+
+  ## run_list
+  # configuration "default"
+  configuration "test"
+end

--- a/test/kitchen/cookbooks/xbuild_attributes/README.md
+++ b/test/kitchen/cookbooks/xbuild_attributes/README.md
@@ -1,0 +1,68 @@
+xbuild_attributes Cookbook
+==========================
+TODO: Enter the cookbook description here.
+
+e.g.
+This cookbook makes your favorite breakfast sandwhich.
+
+Requirements
+------------
+TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
+
+e.g.
+#### packages
+- `toaster` - xbuild_attributes needs toaster to brown your bagel.
+
+Attributes
+----------
+TODO: List you cookbook attributes here.
+
+e.g.
+#### xbuild_attributes::default
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['xbuild_attributes']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
+
+Usage
+-----
+#### xbuild_attributes::default
+TODO: Write usage instructions for each cookbook.
+
+e.g.
+Just include `xbuild_attributes` in your node's `run_list`:
+
+```json
+{
+  "name":"my_node",
+  "run_list": [
+    "recipe[xbuild_attributes]"
+  ]
+}
+```
+
+Contributing
+------------
+TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.
+
+e.g.
+1. Fork the repository on Github
+2. Create a named feature branch (like `add_component_x`)
+3. Write you change
+4. Write tests for your change (if applicable)
+5. Run the tests, ensuring they all pass
+6. Submit a Pull Request using Github
+
+License and Authors
+-------------------
+Authors: TODO: List authors

--- a/test/kitchen/cookbooks/xbuild_attributes/metadata.rb
+++ b/test/kitchen/cookbooks/xbuild_attributes/metadata.rb
@@ -1,0 +1,7 @@
+name             'xbuild_attributes'
+maintainer       'YOUR_COMPANY_NAME'
+maintainer_email 'YOUR_EMAIL'
+license          'All rights reserved'
+description      'Installs/Configures xbuild_attributes'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'

--- a/test/kitchen/cookbooks/xbuild_attributes/recipes/default.rb
+++ b/test/kitchen/cookbooks/xbuild_attributes/recipes/default.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: xbuild_attributes
+# Recipe:: default
+#
+# Copyright 2013, YOUR_COMPANY_NAME
+#
+# All rights reserved - Do Not Redistribute
+#
+
+node.set[:perl][:version] = '5.16.3'
+node.set[:perl][:prefix] = '/usr/local/bin/perl-5.16.3'
+
+node.set[:ruby][:version] = '1.9.3-p392'
+node.set[:ruby][:prefix] = '/usr/local/bin/ruby-1.9.3'
+
+node.set[:php][:version] = '5.5snapshot'
+node.set[:php][:prefix] = '/usr/local/bin/php-5.5snapshot'
+node.set[:php][:options] = '--with-pear'
+
+node.set[:python][:version] = '2.7.3'
+node.set[:python][:prefix] = '/usr/local/bin/python-2.7.3'
+
+node.set[:node][:version] = 'v0.10.1'
+node.set[:node][:prefix] = '/usr/local/bin/node-0.10.1'


### PR DESCRIPTION
Opscodeのtest-kitchen下で、複数プラットフォームのCookbookテストが走るようにしました。

ついでにでubuntu12向けに2箇所、Syntax修正と依存の追加をしています。

```
bundle
kitchen test  # 全Platform
kitchen test --platform centos-6.3      # 個別テスト
kitchen test --platform ubuntu-12.04  # 個別テスト
```

phpはブログのほうでもコケそうとなっていたのでとりあえずdebian未サポートです。
