### PR TITLE
AmazonAMI対応

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@ default['xbuild']['path'] = '/usr/local/bin/xbuild'
 default['xbuild']['include_recipes'] = %w{ git build-essential }
 
 case node[:platform]
-when 'redhat', 'centos'
+when 'redhat', 'centos', 'amazon'
   default['xbuild']['depends'] = %w{
     openssl-devel
     zlib-devel


### PR DESCRIPTION
AmazonのAMI上で動かした時にCentOS用のパッケージを使うように変更してみました。
よろしければご検討下さい。
