### PR TITLE
ubuntu時のdependsバグ

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@ when 'redhat', 'centos', 'amazon'
     yum::repoforge
   })
 when 'ubuntu', 'debian'
-  default['xbuild']['depends'] = %{
+  default['xbuild']['depends'] = %w{
     build-essential
     openssl
     libssl-dev


### PR DESCRIPTION
ubuntu時のdepends変数が配列になっていないようだったので直してみました
